### PR TITLE
fix: sqgen-mysql has no commands

### DIFF
--- a/cmd/sqgen-mysql/main.go
+++ b/cmd/sqgen-mysql/main.go
@@ -58,6 +58,8 @@ var (
 )
 
 func init() {
+	sqgenCmd.AddCommand(tablesCmd)
+
 	tablesDatabase = tablesCmd.Flags().String("database", "", "(required) Database URL")
 	tablesDirectory = tablesCmd.Flags().
 		String("directory", filepath.Join(currdir, "tables"), "(optional) Directory to place the generated file. Can be absolute or relative filepath")


### PR DESCRIPTION
`sqgen-mysql` was doing nothing (except printing `Code generation for the sq package`), because the `tables` command was never actually added.

Unrelatedly, I think this is a really interesting take on a golang query builder, and I really like the idea! The docs are *exceptionally* good too, awesome work there.